### PR TITLE
Support for magnet uris.

### DIFF
--- a/btc/btc_add.py
+++ b/btc/btc_add.py
@@ -22,12 +22,21 @@ def main():
         args.url = not args.file
 
     if args.url:
-        args.value = utils.httpize(args.value)
-        try:
-            torrent = utils.get(args.value, utf8=False)
-        except utils.HTTPError:
-            error('invalid url: %s' % args.value)
-        client.add_torrent_url(args.value)
+        #if given URI starts with "magnet:?" then it's probably a magnet link
+        if args.value.startswith('magnet:?'):
+            #magnets with bittorrent info hash have "xt=urn:btih:"
+            if args.value.find("xt=urn:btih")>0:
+                client.add_torrent_url(args.value)
+                #TODO: Display confirmation about magnet having been added
+                #returning, because decoding torrent will report invalid file
+                return
+        else:
+            args.value = utils.httpize(args.value)
+            try:
+                torrent = utils.get(args.value, utf8=False)
+            except utils.HTTPError:
+                error('invalid url: %s' % args.value)
+            client.add_torrent_url(args.value)
     elif args.file:
         if not os.path.exists(args.value):
             error('no such file: %s' % args.value)


### PR DESCRIPTION
Added support for handling magnet URI when adding using -u option.

Examplary usage:
btc add -u
"magnet:?xt=urn:btih:91ea15451a642d7ff25485e0441ae869b86b4467&dn=ubuntu-12.04.2-desktop-i386.iso&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80&tr=udp%3A%2F%2Ftracker.istole.it%3A6969&tr=udp%3A%2F%2Ftracker.ccc.de%3A80&tr=udp%3A%2F%2Fopen.demonii.com%3A1337"